### PR TITLE
Removing the 900913 projection from the default configuration

### DIFF
--- a/autotest/autotest/conf/eoxserver.conf
+++ b/autotest/autotest/conf/eoxserver.conf
@@ -78,8 +78,9 @@ role=Service provider
 [services.ows.wms]
 
 # CRSes supported by WMS (EPSG code; uncomment to set non-default values)
-# Default: 4326,3857,900913,3035
-supported_crs=4326,3857,900913, # WGS84, WGS84 Pseudo-Mercator, and GoogleEarth spherical mercator
+# Default: 4326,3857,3035
+supported_crs=4326, # WGS84
+	3857, # WGS84 Pseudo-Mercator
 	3035, #ETRS89
 	32661,32761, # WGS84 UPS-N and UPS-S 
 	32601,32602,32603,32604,32605,32606,32607,32608,32609,32610, # WGS84 UTM  1N-10N 
@@ -103,9 +104,10 @@ mask_names=clouds
 [services.ows.wcs]
 
 # CRSes supported by WCS (EPSG code; uncomment to set non-default values)
-# Default: 4326,3857,900913,3035
-#supported_crs=4326,3857,900913, # WGS84, WGS84 Pseudo-Mercator, and GoogleEarth spherical mercator
-#	3035, #ETRS89
+# Default: 4326,3857,3035
+#supported_crs=4326, # WGS84
+#	3857, # WGS84 Pseudo-Mercator
+#	3035, # ETRS89
 #	32661,32761, # WGS84 UPS-N and UPS-S 
 #	32601,32602,32603,32604,32605,32606,32607,32608,32609,32610, # WGS84 UTM  1N-10N 
 #	32611,32612,32613,32614,32615,32616,32617,32618,32619,32620, # WGS84 UTM 11N-20N 

--- a/autotest/autotest/expected/SecWCS20GetCapabilitiesValidAuthorizedTestCase.xml
+++ b/autotest/autotest/expected/SecWCS20GetCapabilitiesValidAuthorizedTestCase.xml
@@ -135,7 +135,6 @@ Copyright (C) European Space Agency - ESA
     <wcs:Extension>
       <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/4326</crs:crsSupported>
       <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3857</crs:crsSupported>
-      <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/900913</crs:crsSupported>
       <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3035</crs:crsSupported>
     </wcs:Extension>
   </wcs:ServiceMetadata>

--- a/autotest/autotest/expected/SecWCS20PostGetCapabilitiesValidTestCase.xml
+++ b/autotest/autotest/expected/SecWCS20PostGetCapabilitiesValidTestCase.xml
@@ -135,7 +135,6 @@ Copyright (C) European Space Agency - ESA
     <wcs:Extension>
       <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/4326</crs:crsSupported>
       <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3857</crs:crsSupported>
-      <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/900913</crs:crsSupported>
       <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3035</crs:crsSupported>
     </wcs:Extension>
   </wcs:ServiceMetadata>

--- a/autotest/autotest/expected/SecWMS13GetCapabilitiesValidTestCase.xml
+++ b/autotest/autotest/expected/SecWMS13GetCapabilitiesValidTestCase.xml
@@ -164,7 +164,6 @@ Copyright (C) European Space Agency - ESA
       </KeywordList>
       <CRS>EPSG:4326</CRS>
       <CRS>EPSG:3857</CRS>
-      <CRS>EPSG:900913</CRS>
       <CRS>EPSG:3035</CRS>
       <EX_GeographicBoundingBox>
         <westBoundLongitude>-1</westBoundLongitude>

--- a/autotest/autotest/expected/WCS10DescribeCoverageDatasetTestCase.xml
+++ b/autotest/autotest/expected/WCS10DescribeCoverageDatasetTestCase.xml
@@ -76,7 +76,6 @@
     <supportedCRSs>
       <requestResponseCRSs>EPSG:4326</requestResponseCRSs>
       <requestResponseCRSs>EPSG:3857</requestResponseCRSs>
-      <requestResponseCRSs>EPSG:900913</requestResponseCRSs>
       <requestResponseCRSs>EPSG:3035</requestResponseCRSs>
       <nativeCRSs>EPSG:4326</nativeCRSs>
     </supportedCRSs>

--- a/autotest/autotest/expected/WCS10DescribeCoverageMosaicTestCase.xml
+++ b/autotest/autotest/expected/WCS10DescribeCoverageMosaicTestCase.xml
@@ -76,7 +76,6 @@
     <supportedCRSs>
       <requestResponseCRSs>EPSG:4326</requestResponseCRSs>
       <requestResponseCRSs>EPSG:3857</requestResponseCRSs>
-      <requestResponseCRSs>EPSG:900913</requestResponseCRSs>
       <requestResponseCRSs>EPSG:3035</requestResponseCRSs>
       <nativeCRSs>EPSG:4326</nativeCRSs>
     </supportedCRSs>

--- a/autotest/autotest/expected/WCS11DescribeCoverageDatasetTestCase.xml
+++ b/autotest/autotest/expected/WCS11DescribeCoverageDatasetTestCase.xml
@@ -49,7 +49,6 @@
     </Range>
     <SupportedCRS>urn:ogc:def:crs:EPSG::4326</SupportedCRS>
     <SupportedCRS>urn:ogc:def:crs:EPSG::3857</SupportedCRS>
-    <SupportedCRS>urn:ogc:def:crs:EPSG::900913</SupportedCRS>
     <SupportedCRS>urn:ogc:def:crs:EPSG::3035</SupportedCRS>
     <SupportedFormat>image/tiff</SupportedFormat>
     <SupportedFormat>image/jp2</SupportedFormat>

--- a/autotest/autotest/expected/WCS11DescribeCoverageMosaicTestCase.xml
+++ b/autotest/autotest/expected/WCS11DescribeCoverageMosaicTestCase.xml
@@ -49,7 +49,6 @@
     </Range>
     <SupportedCRS>urn:ogc:def:crs:EPSG::4326</SupportedCRS>
     <SupportedCRS>urn:ogc:def:crs:EPSG::3857</SupportedCRS>
-    <SupportedCRS>urn:ogc:def:crs:EPSG::900913</SupportedCRS>
     <SupportedCRS>urn:ogc:def:crs:EPSG::3035</SupportedCRS>
     <SupportedFormat>image/tiff</SupportedFormat>
     <SupportedFormat>image/jp2</SupportedFormat>

--- a/autotest/autotest/expected/WCS11GetCapabilitiesValidTestCase.xml
+++ b/autotest/autotest/expected/WCS11GetCapabilitiesValidTestCase.xml
@@ -155,7 +155,6 @@ Copyright (C) European Space Agency - ESA</ows:Abstract>
       </ows:WGS84BoundingBox>
       <SupportedCRS>urn:ogc:def:crs:EPSG::4326</SupportedCRS>
       <SupportedCRS>urn:ogc:def:crs:EPSG::3857</SupportedCRS>
-      <SupportedCRS>urn:ogc:def:crs:EPSG::900913</SupportedCRS>
       <SupportedCRS>urn:ogc:def:crs:EPSG::3035</SupportedCRS>
       <SupportedFormat>image/tiff</SupportedFormat>
       <SupportedFormat>image/jp2</SupportedFormat>
@@ -173,7 +172,6 @@ Copyright (C) European Space Agency - ESA</ows:Abstract>
       </ows:WGS84BoundingBox>
       <SupportedCRS>urn:ogc:def:crs:EPSG::4326</SupportedCRS>
       <SupportedCRS>urn:ogc:def:crs:EPSG::3857</SupportedCRS>
-      <SupportedCRS>urn:ogc:def:crs:EPSG::900913</SupportedCRS>
       <SupportedCRS>urn:ogc:def:crs:EPSG::3035</SupportedCRS>
       <SupportedFormat>image/tiff</SupportedFormat>
       <SupportedFormat>image/jp2</SupportedFormat>
@@ -191,7 +189,6 @@ Copyright (C) European Space Agency - ESA</ows:Abstract>
       </ows:WGS84BoundingBox>
       <SupportedCRS>urn:ogc:def:crs:EPSG::4326</SupportedCRS>
       <SupportedCRS>urn:ogc:def:crs:EPSG::3857</SupportedCRS>
-      <SupportedCRS>urn:ogc:def:crs:EPSG::900913</SupportedCRS>
       <SupportedCRS>urn:ogc:def:crs:EPSG::3035</SupportedCRS>
       <SupportedFormat>image/tiff</SupportedFormat>
       <SupportedFormat>image/jp2</SupportedFormat>
@@ -209,7 +206,6 @@ Copyright (C) European Space Agency - ESA</ows:Abstract>
       </ows:WGS84BoundingBox>
       <SupportedCRS>urn:ogc:def:crs:EPSG::4326</SupportedCRS>
       <SupportedCRS>urn:ogc:def:crs:EPSG::3857</SupportedCRS>
-      <SupportedCRS>urn:ogc:def:crs:EPSG::900913</SupportedCRS>
       <SupportedCRS>urn:ogc:def:crs:EPSG::3035</SupportedCRS>
       <SupportedFormat>image/tiff</SupportedFormat>
       <SupportedFormat>image/jp2</SupportedFormat>

--- a/autotest/autotest/expected/WCS11PostDescribeCoverageDatasetTestCase.xml
+++ b/autotest/autotest/expected/WCS11PostDescribeCoverageDatasetTestCase.xml
@@ -49,7 +49,6 @@
     </Range>
     <SupportedCRS>urn:ogc:def:crs:EPSG::4326</SupportedCRS>
     <SupportedCRS>urn:ogc:def:crs:EPSG::3857</SupportedCRS>
-    <SupportedCRS>urn:ogc:def:crs:EPSG::900913</SupportedCRS>
     <SupportedCRS>urn:ogc:def:crs:EPSG::3035</SupportedCRS>
     <SupportedFormat>image/tiff</SupportedFormat>
     <SupportedFormat>image/jp2</SupportedFormat>

--- a/autotest/autotest/expected/WCS11PostDescribeCoverageMosaicTestCase.xml
+++ b/autotest/autotest/expected/WCS11PostDescribeCoverageMosaicTestCase.xml
@@ -49,7 +49,6 @@
     </Range>
     <SupportedCRS>urn:ogc:def:crs:EPSG::4326</SupportedCRS>
     <SupportedCRS>urn:ogc:def:crs:EPSG::3857</SupportedCRS>
-    <SupportedCRS>urn:ogc:def:crs:EPSG::900913</SupportedCRS>
     <SupportedCRS>urn:ogc:def:crs:EPSG::3035</SupportedCRS>
     <SupportedFormat>image/tiff</SupportedFormat>
     <SupportedFormat>image/jp2</SupportedFormat>

--- a/autotest/autotest/expected/WCS11PostGetCapabilitiesValidTestCase.xml
+++ b/autotest/autotest/expected/WCS11PostGetCapabilitiesValidTestCase.xml
@@ -155,7 +155,6 @@ Copyright (C) European Space Agency - ESA</ows:Abstract>
       </ows:WGS84BoundingBox>
       <SupportedCRS>urn:ogc:def:crs:EPSG::4326</SupportedCRS>
       <SupportedCRS>urn:ogc:def:crs:EPSG::3857</SupportedCRS>
-      <SupportedCRS>urn:ogc:def:crs:EPSG::900913</SupportedCRS>
       <SupportedCRS>urn:ogc:def:crs:EPSG::3035</SupportedCRS>
       <SupportedFormat>image/tiff</SupportedFormat>
       <SupportedFormat>image/jp2</SupportedFormat>
@@ -173,7 +172,6 @@ Copyright (C) European Space Agency - ESA</ows:Abstract>
       </ows:WGS84BoundingBox>
       <SupportedCRS>urn:ogc:def:crs:EPSG::4326</SupportedCRS>
       <SupportedCRS>urn:ogc:def:crs:EPSG::3857</SupportedCRS>
-      <SupportedCRS>urn:ogc:def:crs:EPSG::900913</SupportedCRS>
       <SupportedCRS>urn:ogc:def:crs:EPSG::3035</SupportedCRS>
       <SupportedFormat>image/tiff</SupportedFormat>
       <SupportedFormat>image/jp2</SupportedFormat>
@@ -191,7 +189,6 @@ Copyright (C) European Space Agency - ESA</ows:Abstract>
       </ows:WGS84BoundingBox>
       <SupportedCRS>urn:ogc:def:crs:EPSG::4326</SupportedCRS>
       <SupportedCRS>urn:ogc:def:crs:EPSG::3857</SupportedCRS>
-      <SupportedCRS>urn:ogc:def:crs:EPSG::900913</SupportedCRS>
       <SupportedCRS>urn:ogc:def:crs:EPSG::3035</SupportedCRS>
       <SupportedFormat>image/tiff</SupportedFormat>
       <SupportedFormat>image/jp2</SupportedFormat>
@@ -209,7 +206,6 @@ Copyright (C) European Space Agency - ESA</ows:Abstract>
       </ows:WGS84BoundingBox>
       <SupportedCRS>urn:ogc:def:crs:EPSG::4326</SupportedCRS>
       <SupportedCRS>urn:ogc:def:crs:EPSG::3857</SupportedCRS>
-      <SupportedCRS>urn:ogc:def:crs:EPSG::900913</SupportedCRS>
       <SupportedCRS>urn:ogc:def:crs:EPSG::3035</SupportedCRS>
       <SupportedFormat>image/tiff</SupportedFormat>
       <SupportedFormat>image/jp2</SupportedFormat>

--- a/autotest/autotest/expected/WCS20CorrigendumGetCapabilitiesEmptyTestCase.xml
+++ b/autotest/autotest/expected/WCS20CorrigendumGetCapabilitiesEmptyTestCase.xml
@@ -158,7 +158,6 @@ Copyright (C) European Space Agency - ESA</ows:Abstract>
       <crs:CrsMetadata>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/4326</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3857</crs:crsSupported>
-        <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/900913</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3035</crs:crsSupported>
       </crs:CrsMetadata>
       <int:InterpolationMetadata>

--- a/autotest/autotest/expected/WCS20GetCapabilitiesEmptyTestCase.xml
+++ b/autotest/autotest/expected/WCS20GetCapabilitiesEmptyTestCase.xml
@@ -158,7 +158,6 @@ Copyright (C) European Space Agency - ESA</ows:Abstract>
       <crs:CrsMetadata>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/4326</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3857</crs:crsSupported>
-        <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/900913</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3035</crs:crsSupported>
       </crs:CrsMetadata>
       <int:InterpolationMetadata>

--- a/autotest/autotest/expected/WCS20GetCapabilitiesSectionsAll2TestCase.xml
+++ b/autotest/autotest/expected/WCS20GetCapabilitiesSectionsAll2TestCase.xml
@@ -158,7 +158,6 @@ Copyright (C) European Space Agency - ESA</ows:Abstract>
       <crs:CrsMetadata>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/4326</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3857</crs:crsSupported>
-        <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/900913</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3035</crs:crsSupported>
       </crs:CrsMetadata>
       <int:InterpolationMetadata>

--- a/autotest/autotest/expected/WCS20GetCapabilitiesSectionsAll3TestCase.xml
+++ b/autotest/autotest/expected/WCS20GetCapabilitiesSectionsAll3TestCase.xml
@@ -158,7 +158,6 @@ Copyright (C) European Space Agency - ESA</ows:Abstract>
       <crs:CrsMetadata>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/4326</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3857</crs:crsSupported>
-        <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/900913</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3035</crs:crsSupported>
       </crs:CrsMetadata>
       <int:InterpolationMetadata>

--- a/autotest/autotest/expected/WCS20GetCapabilitiesSectionsAllTestCase.xml
+++ b/autotest/autotest/expected/WCS20GetCapabilitiesSectionsAllTestCase.xml
@@ -158,7 +158,6 @@ Copyright (C) European Space Agency - ESA</ows:Abstract>
       <crs:CrsMetadata>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/4326</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3857</crs:crsSupported>
-        <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/900913</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3035</crs:crsSupported>
       </crs:CrsMetadata>
       <int:InterpolationMetadata>

--- a/autotest/autotest/expected/WCS20GetCapabilitiesValidTestCase.xml
+++ b/autotest/autotest/expected/WCS20GetCapabilitiesValidTestCase.xml
@@ -158,7 +158,6 @@ Copyright (C) European Space Agency - ESA</ows:Abstract>
       <crs:CrsMetadata>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/4326</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3857</crs:crsSupported>
-        <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/900913</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3035</crs:crsSupported>
       </crs:CrsMetadata>
       <int:InterpolationMetadata>

--- a/autotest/autotest/expected/WCS20PostGetCapabilitiesValidTestCase.xml
+++ b/autotest/autotest/expected/WCS20PostGetCapabilitiesValidTestCase.xml
@@ -158,7 +158,6 @@ Copyright (C) European Space Agency - ESA</ows:Abstract>
       <crs:CrsMetadata>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/4326</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3857</crs:crsSupported>
-        <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/900913</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3035</crs:crsSupported>
       </crs:CrsMetadata>
       <int:InterpolationMetadata>

--- a/autotest/autotest/expected/WCSVersionNegotiationNewStyleTestCase.xml
+++ b/autotest/autotest/expected/WCSVersionNegotiationNewStyleTestCase.xml
@@ -158,7 +158,6 @@ Copyright (C) European Space Agency - ESA</ows:Abstract>
       <crs:CrsMetadata>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/4326</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3857</crs:crsSupported>
-        <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/900913</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3035</crs:crsSupported>
       </crs:CrsMetadata>
       <int:InterpolationMetadata>

--- a/autotest/autotest/expected/WCSVersionNegotiationOldStyleTestCase.xml
+++ b/autotest/autotest/expected/WCSVersionNegotiationOldStyleTestCase.xml
@@ -158,7 +158,6 @@ Copyright (C) European Space Agency - ESA</ows:Abstract>
       <crs:CrsMetadata>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/4326</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3857</crs:crsSupported>
-        <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/900913</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3035</crs:crsSupported>
       </crs:CrsMetadata>
       <int:InterpolationMetadata>

--- a/autotest/autotest/expected/WCSVersionNegotiationTestCase.xml
+++ b/autotest/autotest/expected/WCSVersionNegotiationTestCase.xml
@@ -158,7 +158,6 @@ Copyright (C) European Space Agency - ESA</ows:Abstract>
       <crs:CrsMetadata>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/4326</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3857</crs:crsSupported>
-        <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/900913</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3035</crs:crsSupported>
       </crs:CrsMetadata>
       <int:InterpolationMetadata>

--- a/autotest/autotest/expected/WMS13GetCapabilitiesValidTestCase.xml
+++ b/autotest/autotest/expected/WMS13GetCapabilitiesValidTestCase.xml
@@ -158,7 +158,6 @@ Copyright (C) European Space Agency - ESA</Abstract>
       </KeywordList>
       <CRS>EPSG:4326</CRS>
       <CRS>EPSG:3857</CRS>
-      <CRS>EPSG:900913</CRS>
       <CRS>EPSG:3035</CRS>
       <EX_GeographicBoundingBox>
         <westBoundLongitude>-3.43798</westBoundLongitude>

--- a/autotest/autotest/expected/WMSVersionNegotiationNewStyleTestCase.xml
+++ b/autotest/autotest/expected/WMSVersionNegotiationNewStyleTestCase.xml
@@ -158,7 +158,6 @@ Copyright (C) European Space Agency - ESA</Abstract>
       </KeywordList>
       <CRS>EPSG:4326</CRS>
       <CRS>EPSG:3857</CRS>
-      <CRS>EPSG:900913</CRS>
       <CRS>EPSG:3035</CRS>
       <EX_GeographicBoundingBox>
         <westBoundLongitude>-3.43798</westBoundLongitude>

--- a/autotest/autotest/expected/WMSVersionNegotiationOldStyleTestCase.xml
+++ b/autotest/autotest/expected/WMSVersionNegotiationOldStyleTestCase.xml
@@ -158,7 +158,6 @@ Copyright (C) European Space Agency - ESA</Abstract>
       </KeywordList>
       <CRS>EPSG:4326</CRS>
       <CRS>EPSG:3857</CRS>
-      <CRS>EPSG:900913</CRS>
       <CRS>EPSG:3035</CRS>
       <EX_GeographicBoundingBox>
         <westBoundLongitude>-3.43798</westBoundLongitude>

--- a/autotest/autotest/expected/WMSVersionNegotiationTestCase.xml
+++ b/autotest/autotest/expected/WMSVersionNegotiationTestCase.xml
@@ -158,7 +158,6 @@ Copyright (C) European Space Agency - ESA</Abstract>
       </KeywordList>
       <CRS>EPSG:4326</CRS>
       <CRS>EPSG:3857</CRS>
-      <CRS>EPSG:900913</CRS>
       <CRS>EPSG:3035</CRS>
       <EX_GeographicBoundingBox>
         <westBoundLongitude>-3.43798</westBoundLongitude>

--- a/autotest/autotest/expected/command_line_test_getcapabilities.xml
+++ b/autotest/autotest/expected/command_line_test_getcapabilities.xml
@@ -158,7 +158,6 @@ Copyright (C) European Space Agency - ESA</ows:Abstract>
       <crs:CrsMetadata>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/4326</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3857</crs:crsSupported>
-        <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/900913</crs:crsSupported>
         <crs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3035</crs:crsSupported>
       </crs:CrsMetadata>
       <int:InterpolationMetadata>

--- a/eoxserver/conf/default.conf
+++ b/eoxserver/conf/default.conf
@@ -110,7 +110,8 @@ reservation_time=0:0:30:0
 [services.ows.wms]
 
 # CRSes supported by WMS (EPSG code)
-supported_crs=4326,3857,900913, # WGS84, WGS84 Pseudo-Mercator, and GoogleEarth spherical mercator
+supported_crs=4326, # WGS84
+    3857, # WGS84 Pseudo-Mercator, and GoogleEarth spherical mercator
 	3035 #ETRS89
 
 # file formats supported by WMS 
@@ -119,7 +120,8 @@ supported_formats=image/png,image/jpeg
 [services.ows.wcs]
 
 # CRSes supported by WCS (EPSG code) 
-supported_crs=4326,3857,900913, # WGS84, WGS84 Pseudo-Mercator, and GoogleEarth spherical mercator
+supported_crs=4326, # WGS84
+    3857, # WGS84 Pseudo-Mercator, and GoogleEarth spherical mercator
 	3035 #ETRS89
 
 # file formats supported by WCS 

--- a/eoxserver/instance_template/project_name/conf/eoxserver.conf
+++ b/eoxserver/instance_template/project_name/conf/eoxserver.conf
@@ -74,9 +74,10 @@ role=Service provider
 [services.ows.wms]
 
 # CRSes supported by WMS (EPSG code; uncomment to set non-default values)
-# Default: 4326,3857,900913,3035
-#supported_crs=4326,3857,900913, # WGS84, WGS84 Pseudo-Mercator, and GoogleEarth spherical mercator
-#	3035, #ETRS89
+# Default: 4326,3857,3035
+#supported_crs=4326, # WGS84
+#	3857, # WGS84 Pseudo-Mercator
+#	3035, # ETRS89
 #	32661,32761, # WGS84 UPS-N and UPS-S
 #	32601,32602,32603,32604,32605,32606,32607,32608,32609,32610, # WGS84 UTM  1N-10N
 #	32611,32612,32613,32614,32615,32616,32617,32618,32619,32620, # WGS84 UTM 11N-20N
@@ -99,9 +100,10 @@ mask_names=clouds
 [services.ows.wcs]
 
 # CRSes supported by WCS (EPSG code; uncomment to set non-default values)
-# Default: 4326,3857,900913,3035
-#supported_crs=4326,3857,900913, # WGS84, WGS84 Pseudo-Mercator, and GoogleEarth spherical mercator
-#	3035, #ETRS89
+# Default: 4326,3857,3035
+#supported_crs=4326, # WGS84
+#	3857, # WGS84 Pseudo-Mercator
+#	3035, # ETRS89
 #	32661,32761, # WGS84 UPS-N and UPS-S
 #	32601,32602,32603,32604,32605,32606,32607,32608,32609,32610, # WGS84 UTM  1N-10N
 #	32611,32612,32613,32614,32615,32616,32617,32618,32619,32620, # WGS84 UTM 11N-20N


### PR DESCRIPTION
Note that:
- EPSG:900913 has been superseded by EPSG:3857.
- EPSG:900913 is not recognised by the Proj4 library configuration and the
 default EOxServer out-of-the-box instance configuration fails.