### PR TITLE
adjusting geotiff error massages

### DIFF
--- a/autotest/autotest_services/tests/wcs/test_v20.py
+++ b/autotest/autotest_services/tests/wcs/test_v20.py
@@ -1518,3 +1518,94 @@ class WCS20GetCoverageDatasetGeoTIFFPostTestCase(wcsbase.GeoTIFFMixIn, testbase.
           </wcs:Extension>
         </wcs:GetCoverage>"""
         return (params, "xml")
+
+@tag('wcs', 'wcs20')
+class WCS20GetCoverageDatasetGeoTIFFCompressionNotSupportedTestCase(testbase.ExceptionTestCase):
+
+    def getRequest(self):
+        params = "service=wcs&version=2.0.0&request=GetCoverage&CoverageId=mosaic_MER_FRS_1PNPDE20060830_100949_000001972050_00423_23523_0079_RGB_reduced&format=image/tiff&geotiff:compression=PackBits&geotiff:jpeg_quality=90"
+        return (params, "kvp")
+
+    def getExpectedHTTPStatus(self):
+        return 404
+
+    def getExpectedExceptionCode(self):
+        return "CompressionNotSupported"
+
+@tag('wcs', 'wcs20')
+class WCS20GetCoverageDatasetGeoTIFFCompressionInvalidTestCase(testbase.ExceptionTestCase):
+
+    def getRequest(self):
+        params = "service=wcs&version=2.0.0&request=GetCoverage&CoverageId=mosaic_MER_FRS_1PNPDE20060830_100949_000001972050_00423_23523_0079_RGB_reduced&format=image/tiff&geotiff:compression=notValid"
+        return (params, "kvp")
+
+    def getExpectedHTTPStatus(self):
+        return 404
+
+    def getExpectedExceptionCode(self):
+        return "CompressionInvalid"
+
+@tag('wcs', 'wcs20')
+class WCS20GetCoverageDatasetGeoTIFFJpegQualityInvalidTestCase(testbase.ExceptionTestCase):
+
+    def getRequest(self):
+        params = "service=wcs&version=2.0.0&request=GetCoverage&CoverageId=mosaic_MER_FRS_1PNPDE20060830_100949_000001972050_00423_23523_0079_RGB_reduced&format=image/tiff&geotiff:compression=JPEG&geotiff:jpeg_quality=900"
+        return (params, "kvp")
+
+    def getExpectedHTTPStatus(self):
+        return 404
+
+    def getExpectedExceptionCode(self):
+        return "JpegQualityInvalid"
+
+@tag('wcs', 'wcs20')
+class WCS20GetCoverageDatasetGeoTIFFPredictorInvalidTestCase(testbase.ExceptionTestCase):
+
+    def getRequest(self):
+        params = "service=wcs&version=2.0.0&request=GetCoverage&CoverageId=mosaic_MER_FRS_1PNPDE20060830_100949_000001972050_00423_23523_0079_RGB_reduced&format=image/tiff&geotiff:compression=Deflate&geotiff:predictor=invalid"
+        return (params, "kvp")
+
+    def getExpectedHTTPStatus(self):
+        return 404
+
+    def getExpectedExceptionCode(self):
+        return "PredictorInvalid"
+
+@tag('wcs', 'wcs20')
+class WCS20GetCoverageDatasetGeoTIFFPredictorNotSupportedTestCase(testbase.ExceptionTestCase):
+
+    def getRequest(self):
+        params = "service=wcs&version=2.0.0&request=GetCoverage&CoverageId=mosaic_MER_FRS_1PNPDE20060830_100949_000001972050_00423_23523_0079_RGB_reduced&format=image/tiff&geotiff:compression=JPEG&geotiff:predictor=FloatingPoint"
+        return (params, "kvp")
+
+    def getExpectedHTTPStatus(self):
+        return 404
+
+    def getExpectedExceptionCode(self):
+        return "PredictorNotSupported"
+
+@tag('wcs', 'wcs20')
+class WCS20GetCoverageDatasetGeoTIFFInterleavingInvalidTestCase(testbase.ExceptionTestCase):
+
+    def getRequest(self):
+        params = "service=wcs&version=2.0.0&request=GetCoverage&CoverageId=mosaic_MER_FRS_1PNPDE20060830_100949_000001972050_00423_23523_0079_RGB_reduced&format=image/tiff&geotiff:Interleave=invalid"
+        return (params, "kvp")
+
+    def getExpectedHTTPStatus(self):
+        return 404
+
+    def getExpectedExceptionCode(self):
+        return "InterleavingInvalid"
+
+@tag('wcs', 'wcs20')
+class WCS20GetCoverageDatasetGeoTIFFTilingInvalidTestCase(testbase.ExceptionTestCase):
+    """this test send a request where tiling is set to true, tile width is 16 but tile height is missing"""
+    def getRequest(self):
+        params = "service=wcs&version=2.0.0&request=GetCoverage&CoverageId=mosaic_MER_FRS_1PNPDE20060830_100949_000001972050_00423_23523_0079_RGB_reduced&format=image/tiff&geotiff:tiling=true&geotiff:tilewidth=16"
+        return (params, "kvp")
+
+    def getExpectedHTTPStatus(self):
+        return 404
+
+    def getExpectedExceptionCode(self):
+        return "TilingInvalid"

--- a/eoxserver/core/decoders/__init__.py
+++ b/eoxserver/core/decoders/__init__.py
@@ -212,15 +212,16 @@ class enum(object):
         A ValueError is raised if not.
     """
 
-    def __init__(self, values, case_sensitive=True):
+    def __init__(self, values, case_sensitive=True, error_class= ValueError):
         self.values = values
         self.compare_values = values if case_sensitive else [lower(v) for v in values]
         self.case_sensitive = case_sensitive
+        self.error_class = error_class
 
     def __call__(self, value):
         compare = value if self.case_sensitive else value.lower()
         if compare not in self.compare_values:
-            raise ValueError("Unexpected value '%s'. Expected one of: %s." %
+            raise self.error_class("Unexpected value '%s'. Expected one of: %s." %
                 (value, ", ".join(map(lambda s: "'%s'" % s, self.values)))
             )
 

--- a/eoxserver/core/decoders/__init__.py
+++ b/eoxserver/core/decoders/__init__.py
@@ -212,7 +212,7 @@ class enum(object):
         A ValueError is raised if not.
     """
 
-    def __init__(self, values, case_sensitive=True, error_class= ValueError):
+    def __init__(self, values, case_sensitive=True, error_class=ValueError):
         self.values = values
         self.compare_values = values if case_sensitive else [lower(v) for v in values]
         self.case_sensitive = case_sensitive

--- a/eoxserver/services/ows/wcs/v20/exceptionhandler.py
+++ b/eoxserver/services/ows/wcs/v20/exceptionhandler.py
@@ -38,7 +38,11 @@ CODES_404 = frozenset((
     "NoSuchCoverage", "NoSuchDatasetSeriesOrCoverage", "InvalidAxisLabel",
     "InvalidSubsetting", "InterpolationMethodNotSupported", "NoSuchField",
     "InvalidFieldSequence", "InvalidScaleFactor", "InvalidExtent",
-    "ScaleAxisUndefined", "SubsettingCrs-NotSupported", "OutputCrs-NotSupported"
+    "ScaleAxisUndefined", "SubsettingCrs-NotSupported", "OutputCrs-NotSupported",
+    "CompressionNotSupported", "CompressionInvalid", "JpegQualityInvalid",
+    "PredictorInvalid", "PredictorNotSupported", "InterleavingInvalid",
+    "TilingInvalid"
+
 ))
 
 


### PR DESCRIPTION
according to this issue #357,  this PR adjusts WCS2.0 geotiff exceptions so that they comply with Tab. 2, [OGC 12-100r1](https://portal.opengeospatial.org/files/?artifact_id=54813).
