### PR TITLE
extend available polarisation channels

### DIFF
--- a/eoxserver/resources/coverages/migrations/0010_polarisation_channels_expand.py
+++ b/eoxserver/resources/coverages/migrations/0010_polarisation_channels_expand.py
@@ -13,6 +13,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='productmetadata',
             name='polarization_channels',
-            field=models.PositiveSmallIntegerField(blank=True, choices=[(0, 'HV'), (1, 'HV, VH'), (2, 'VH'), (3, 'VV'), (4, 'HH, VV'), (5, 'HH, VH'), (6, 'HH, HV'), (7, 'VH, VV'), (8, 'VH, HV'), (9, 'VV, HV'), (10, 'VV, VH'), (11, 'HH'), (12, 'HH, HV, VH, VV'), (13, 'HH, VH, HV, VV'), (14, 'HH, VV, HV, VH'), (15, 'HH, VV, VH, HV'), (16, 'UNDEFINED')], db_index=True, null=True),
+            field=models.PositiveSmallIntegerField(blank=True, choices=[(0, 'HV'), (1, 'HV, VH'), (2, 'VH'), (3, 'VV'), (4, 'HH, VV'), (5, 'HH, VH'), (6, 'HH, HV'), (7, 'VH, VV'), (8, 'VH, HV'), (9, 'VV, HV'), (10, 'VV, VH'), (11, 'HH'), (12, 'HH, HV, VH, VV'), (13, 'UNDEFINED'), (14, 'HH, VH, HV, VV'), (15, 'HH, VV, HV, VH'), (16, 'HH, VV, VH, HV')], db_index=True, null=True),
         ),
     ]

--- a/eoxserver/resources/coverages/models.py
+++ b/eoxserver/resources/coverages/models.py
@@ -623,10 +623,10 @@ class ProductMetadata(models.Model):
         (10, "VV, VH"),
         (11, "HH"),
         (12, "HH, HV, VH, VV"),
-        (13, "HH, VH, HV, VV"),
-        (14, "HH, VV, HV, VH"),
-        (15, "HH, VV, VH, HV"),
-        (16, "UNDEFINED"),
+        (13, "UNDEFINED"),
+        (14, "HH, VH, HV, VV"),
+        (15, "HH, VV, HV, VH"),
+        (16, "HH, VV, VH, HV"),
     )
 
     ANTENNA_LOOK_DIRECTION_CHOICES = (


### PR DESCRIPTION
Adds a few polarization channels for SAR data

Reason is that few products we need to register have following value `HH, VV, HV, VH` in metadata field.
Migration was created using `makemigrations` and applied as a test to running instance -> solved the registration issue.