### PR TITLE
add mime type of raster outputs of dem processes

### DIFF
--- a/eoxserver/services/ows/wps/processes/get_dem_processing.py
+++ b/eoxserver/services/ows/wps/processes/get_dem_processing.py
@@ -232,6 +232,8 @@ class DemProcessingProcess(Component):
                 _output = CDByteBuffer(
                     fid.read(), filename=output_filename,
                 )
+                if getattr(_output, 'mime_type', None) is None:
+                    setattr(_output, 'mime_type', result['mime_type'])
         gdal.Unlink(output_filename)
         gdal.Unlink(tmp_ds)
         return _output

--- a/eoxserver/services/ows/wps/processes/get_height_profile.py
+++ b/eoxserver/services/ows/wps/processes/get_height_profile.py
@@ -213,6 +213,8 @@ class GetHeightProfileProcess(Component):
 
             _output = CDByteBuffer(
                     image_data.read(), filename=output_filename,)
+            if getattr(_output, 'mime_type', None) is None:
+                setattr(_output, 'mime_type', profile['mime_type'])
             tmp_ds = None
             return _output
 


### PR DESCRIPTION
- fixes that mime_type of raster outputs of DEM processes was always set to `image/png` 