### PR TITLE
43 custom error page for wcs exceptions

### DIFF
--- a/autotest/autotest_services/tests/wcs/test_v20.py
+++ b/autotest/autotest_services/tests/wcs/test_v20.py
@@ -1633,3 +1633,46 @@ class WCS20GetCoverageDatasetGeoTIFFTilingInvalidTestCase(testbase.ExceptionTest
 
     def getExpectedExceptionCode(self):
         return "TilingInvalid"
+
+
+@tag('wcs', 'wcs20')
+class WCS20DefaultErrorFormatIsXmlTestCase(testbase.OWSTestCase):
+    def getRequest(self):
+        params = "service=WCS&version=2.0.1&request=invalid"
+        return (params, "kvp")
+
+    def testStatus(self):
+        # override base class test case because these results don't return 200 intentionally
+        pass
+
+    def testContentTypeIsXml(self):
+        content_type = self.response.get("Content-Type")
+        self.assertEqual(
+            content_type,
+            "text/xml",
+        )
+
+
+@tag('wcs', 'wcs20')
+class WCS20ErrorFormatIsHtmlOnRequestTestCase(testbase.OWSTestCase):
+    def getRequest(self):
+        params = "service=WCS&version=2.0.1&request=invalid&exceptions=text/html"
+        return (params, "kvp")
+
+    def testStatus(self):
+        # override base class test case because these results don't return 200 intentionally
+        pass
+
+    def testContentTypeIsHtml(self):
+        content_type = self.response.get("Content-Type")
+        self.assertEqual(
+            content_type,
+            "text/html",
+        )
+
+
+
+@tag('wcs', 'wcs20')
+class WCS20POSTErrorFormatIsHtmlOnRequestTestCase(testbase.OWSTestCase):
+    def test_todo(self):
+        self.assertEqual(1, 2)

--- a/autotest/autotest_services/tests/wcs/test_v20.py
+++ b/autotest/autotest_services/tests/wcs/test_v20.py
@@ -1670,6 +1670,12 @@ class WCS20ErrorFormatIsHtmlOnRequestTestCase(testbase.OWSTestCase):
             "text/html",
         )
 
+    def testTemplateContainsErrorMessage(self):
+        self.assertIn(
+            "Error: Operation &#39;INVALID&#39; is not supported",
+            self.response.content.decode(),
+        )
+
 
 
 @tag('wcs', 'wcs20')

--- a/autotest/autotest_services/tests/wcs/test_v20.py
+++ b/autotest/autotest_services/tests/wcs/test_v20.py
@@ -1642,15 +1642,11 @@ class WCS20DefaultErrorFormatIsXmlTestCase(testbase.OWSTestCase):
         return (params, "kvp")
 
     def testStatus(self):
-        # override base class test case because these results don't return 200 intentionally
         pass
 
     def testContentTypeIsXml(self):
         content_type = self.response.get("Content-Type")
-        self.assertEqual(
-            content_type,
-            "text/xml",
-        )
+        self.assertEqual(content_type, "text/xml")
 
 
 @tag('wcs', 'wcs20')
@@ -1660,15 +1656,11 @@ class WCS20ErrorFormatIsHtmlOnRequestTestCase(testbase.OWSTestCase):
         return (params, "kvp")
 
     def testStatus(self):
-        # override base class test case because these results don't return 200 intentionally
         pass
 
     def testContentTypeIsHtml(self):
         content_type = self.response.get("Content-Type")
-        self.assertEqual(
-            content_type,
-            "text/html",
-        )
+        self.assertEqual(content_type, "text/html")
 
     def testTemplateContainsErrorMessage(self):
         self.assertIn(
@@ -1676,9 +1668,39 @@ class WCS20ErrorFormatIsHtmlOnRequestTestCase(testbase.OWSTestCase):
             self.response.content.decode(),
         )
 
+@tag('wcs', 'wcs20')
+class WCS20PostDefaultErrorFormatIsXmlTestCase(testbase.OWSTestCase):
+    def getRequest(self):
+        params = """<ns:invalid updateSequence="u2001" service="WCS"
+          xmlns:ns="http://www.opengis.net/wcs/2.0"
+          xmlns:ns1="http://www.opengis.net/ows/2.0">
+            <ns1:AcceptVersions><ns1:Version>2.0.1</ns1:Version></ns1:AcceptVersions>
+          </ns:invalid>
+        """
+        return (params, "xml")
+
+    def testStatus(self):
+        pass
+
+    def testContentTypeIsHtml(self):
+        content_type = self.response.get("Content-Type")
+        self.assertEqual(content_type, "text/xml")
 
 
 @tag('wcs', 'wcs20')
-class WCS20POSTErrorFormatIsHtmlOnRequestTestCase(testbase.OWSTestCase):
-    def test_todo(self):
-        self.assertEqual(1, 2)
+class WCS20PostErrorFormatIsHtmlOnRequestTestCase(testbase.OWSTestCase):
+    def getRequest(self):
+        params = """<ns:invalid updateSequence="u2001" service="WCS" exceptions="text/html"
+          xmlns:ns="http://www.opengis.net/wcs/2.0"
+          xmlns:ns1="http://www.opengis.net/ows/2.0">
+            <ns1:AcceptVersions><ns1:Version>2.0.1</ns1:Version></ns1:AcceptVersions>
+          </ns:invalid>
+        """
+        return (params, "xml")
+
+    def testStatus(self):
+        pass
+
+    def testContentTypeIsHtml(self):
+        content_type = self.response.get("Content-Type")
+        self.assertEqual(content_type, "text/html")

--- a/autotest/autotest_services/tests/wcs/test_v20.py
+++ b/autotest/autotest_services/tests/wcs/test_v20.py
@@ -1690,10 +1690,14 @@ class WCS20PostDefaultErrorFormatIsXmlTestCase(testbase.OWSTestCase):
 @tag('wcs', 'wcs20')
 class WCS20PostErrorFormatIsHtmlOnRequestTestCase(testbase.OWSTestCase):
     def getRequest(self):
-        params = """<ns:invalid updateSequence="u2001" service="WCS" exceptions="text/html"
+        params = """<ns:invalid updateSequence="u2001" service="WCS"
           xmlns:ns="http://www.opengis.net/wcs/2.0"
-          xmlns:ns1="http://www.opengis.net/ows/2.0">
+          xmlns:ns1="http://www.opengis.net/ows/2.0"
+          xmlns:eoxs="http://eoxserver.org/eoxs/1.0">
             <ns1:AcceptVersions><ns1:Version>2.0.1</ns1:Version></ns1:AcceptVersions>
+            <ns:Extensions>
+                <eoxs:exceptions>text/html</eoxs:exceptions>
+            </ns:Extensions>
           </ns:invalid>
         """
         return (params, "xml")

--- a/autotest/autotest_services/tests/wcs/test_v20.py
+++ b/autotest/autotest_services/tests/wcs/test_v20.py
@@ -1695,9 +1695,9 @@ class WCS20PostErrorFormatIsHtmlOnRequestTestCase(testbase.OWSTestCase):
           xmlns:ns1="http://www.opengis.net/ows/2.0"
           xmlns:eoxs="http://eoxserver.org/eoxs/1.0">
             <ns1:AcceptVersions><ns1:Version>2.0.1</ns1:Version></ns1:AcceptVersions>
-            <ns:Extensions>
+            <ns:Extension>
                 <eoxs:exceptions>text/html</eoxs:exceptions>
-            </ns:Extensions>
+            </ns:Extension>
           </ns:invalid>
         """
         return (params, "xml")

--- a/eoxserver/services/opensearch/config.py
+++ b/eoxserver/services/opensearch/config.py
@@ -60,6 +60,8 @@ DEFAULT_EOXS_OPENSEARCH_RECORD_MODEL = "eoxserver.resources.coverages.models.EOO
 # default ordering (field name) for opensearch queries
 DEFAULT_EOXS_OPENSEARCH_DEFAULT_ORDERING = None
 
+# when True, adds exceptions=text/html to all GetCoverage links in opensearch response
+EOXS_OPENSEARCH_GETCOVERAGE_HTML_EXCEPTION = False
 
 def get_opensearch_record_model():
     class_name = getattr(

--- a/eoxserver/services/opensearch/formats/base.py
+++ b/eoxserver/services/opensearch/formats/base.py
@@ -510,14 +510,18 @@ class BaseFeedResultFormat(object):
         return None
 
     def _create_coverage_link(self, request, coverage):
+        options = dict(
+            service="WCS",
+            version="2.0.1",
+            request="GetCoverage",
+            coverageId=coverage.identifier,
+        )
+        if getattr(settings, 'EOXS_OPENSEARCH_GETCOVERAGE_HTML_EXCEPTION', False):
+            options["exceptions"] = "text/html"
+
         return request.build_absolute_uri(
             "%s?%s" % (
-                reverse("ows"), urlencode(dict(
-                    service="WCS",
-                    version="2.0.1",
-                    request="GetCoverage",
-                    coverageId=coverage.identifier,
-                ))
+                reverse("ows"), urlencode(options)
             )
         )
 

--- a/eoxserver/services/ows/common/v20/encoders.py
+++ b/eoxserver/services/ows/common/v20/encoders.py
@@ -199,7 +199,7 @@ class OWS20Encoder(XMLEncoder):
 
 
 class OWS20ExceptionXMLEncoder(XMLEncoder):
-    def encode_exception(self, message, version, code, locator=None):
+    def encode_exception(self, message, version, code, locator=None, request=None, exception=None):
         exception_attributes = {
             "exceptionCode": str(code)
         }

--- a/eoxserver/services/ows/config.py
+++ b/eoxserver/services/ows/config.py
@@ -66,3 +66,5 @@ DEFAULT_EOXS_OWS_EXCEPTION_HANDLERS = [
     'eoxserver.services.ows.wcs.v20.exceptionhandler.WCS20ExceptionHandler',
     'eoxserver.services.ows.wms.v13.exceptionhandler.WMS13ExceptionHandler',
 ]
+
+DEFAULT_EOXS_WCS_ERROR_HTML_TEMPLATE = "wcs/error_template.html"

--- a/eoxserver/services/ows/wcs/v20/exceptionhandler.py
+++ b/eoxserver/services/ows/wcs/v20/exceptionhandler.py
@@ -25,6 +25,7 @@
 # THE SOFTWARE.
 #-------------------------------------------------------------------------------
 
+import traceback
 
 from django.conf import settings
 from django.template.loader import render_to_string
@@ -79,9 +80,15 @@ class OWS20ExceptionHTMLEncoder(object):
             'EOXS_ERROR_HTML_TEMPLATE',
             DEFAULT_EOXS_WCS_ERROR_HTML_TEMPLATE,
         )
+        # pass in original traceback and debug to allow usage in template
+        debug = getattr(settings, 'DEBUG', False)
+        stack_trace = traceback.format_exc()
+
         template_params = {
             "message": message,
             "exception": exception,
+            "debug": debug,
+            "stack_trace": stack_trace,
         }
         return render_to_string(
             template_name,

--- a/eoxserver/services/ows/wcs/v20/exceptionhandler.py
+++ b/eoxserver/services/ows/wcs/v20/exceptionhandler.py
@@ -34,9 +34,11 @@ from eoxserver.core.decoders import kvp, lower, xml
 from eoxserver.services.ows.interfaces import ExceptionHandlerInterface
 from eoxserver.services.ows.common.v20.encoders import OWS20ExceptionXMLEncoder
 from eoxserver.services.ows.config import DEFAULT_EOXS_WCS_ERROR_HTML_TEMPLATE
+from eoxserver.services.ows.wcs.v20.util import ns_wcs
 from eoxserver.core.decoders import (
     DecodingException, MissingParameterException
 )
+from eoxserver.core.util.xmltools import NameSpace, NameSpaceMap
 
 
 CODES_404 = frozenset((
@@ -56,7 +58,10 @@ class WCS20ExceptionHandlerKVPDecoder(kvp.Decoder):
 
 
 class WCS20ExceptionHandlerXMLDecoder(xml.Decoder):
-    exceptions = xml.Parameter("@exceptions", num="?", type=lower, default="application/xml")
+    namespaces = NameSpaceMap(
+        ns_wcs, NameSpace("http://eoxserver.org/eoxs/1.0", "eoxs")
+    )
+    exceptions = xml.Parameter("wcs:Extensions/eoxs:exceptions/text()", num="?", type=lower, default="application/xml")
 
 
 class OWS20ExceptionHTMLEncoder(object):

--- a/eoxserver/services/ows/wcs/v20/exceptionhandler.py
+++ b/eoxserver/services/ows/wcs/v20/exceptionhandler.py
@@ -62,7 +62,7 @@ class WCS20ExceptionHandlerXMLDecoder(xml.Decoder):
     namespaces = NameSpaceMap(
         ns_wcs, NameSpace("http://eoxserver.org/eoxs/1.0", "eoxs")
     )
-    exceptions = xml.Parameter("wcs:Extensions/eoxs:exceptions/text()", num="?", type=lower, default="application/xml")
+    exceptions = xml.Parameter("wcs:Extension/eoxs:exceptions/text()", num="?", type=lower, default="application/xml")
 
 
 class OWS20ExceptionHTMLEncoder(object):

--- a/eoxserver/services/ows/wcs/v20/exceptionhandler.py
+++ b/eoxserver/services/ows/wcs/v20/exceptionhandler.py
@@ -55,8 +55,8 @@ class WCS20ExceptionHandlerKVPDecoder(kvp.Decoder):
     exceptions = kvp.Parameter(num="?", type=lower, default="application/xml")
 
 
-class WCS20ExceptionHandlerXMLDecoder(kvp.Decoder):
-    exceptions = xml.Parameter("TODO SELECTOR XPATH", num="?", type=lower, default="application/xml")
+class WCS20ExceptionHandlerXMLDecoder(xml.Decoder):
+    exceptions = xml.Parameter("@exceptions", num="?", type=lower, default="application/xml")
 
 
 class OWS20ExceptionHTMLEncoder(object):

--- a/eoxserver/services/templates/wcs/error_template.html
+++ b/eoxserver/services/templates/wcs/error_template.html
@@ -1,0 +1,11 @@
+<html>
+<head>
+    <title>Error: {{ message }}</title>
+</head>
+<body>
+  <h1>Error: {{ message }}</h1>
+  {% if exception.code == 404 %}
+      <p>Not found.</p>
+  {% endif %}
+</body>
+</html>

--- a/eoxserver/services/templates/wcs/error_template.html
+++ b/eoxserver/services/templates/wcs/error_template.html
@@ -7,5 +7,11 @@
   {% if exception.code == 404 %}
       <p>Not found.</p>
   {% endif %}
+  {% if debug %}
+      <h2>DEBUG: Full stack trace</h2>
+      <p>
+        {{ stack_trace }}
+      </p>
+  {% endif %}
 </body>
 </html>


### PR DESCRIPTION
- render HTML template with access to the following variables: `exception, stack_trace, message and debug` in case of Exception for wcs 2.0 if `exceptions=text/html` is passed in GET request or `<wcs:Extenstion><eoxs:exceptions>text/html</eoxs:exceptions></wcs:Extension>` passed in POST request