### PR TITLE
Add cache-control header to urls reachable from VS

### DIFF
--- a/eoxserver/services/config.py
+++ b/eoxserver/services/config.py
@@ -25,4 +25,20 @@
 # THE SOFTWARE.
 # ------------------------------------------------------------------------------
 
-DEFAULT_EOXS_RENDERER_CACHE_TIME = 60 * 60 * 24 * 7
+import typing
+
+from django.conf import settings
+from django.views.decorators.cache import cache_control
+
+_cache_time_str = getattr(settings, "EOXS_RENDERER_CACHE_TIME", None)
+
+EOXS_RENDERER_CACHE_TIME: typing.Optional[int] = (
+    int(_cache_time_str) if _cache_time_str is not None else None
+)
+
+def apply_cache_header(view):
+    return (
+        cache_control(max_age=EOXS_RENDERER_CACHE_TIME)(view)
+        if EOXS_RENDERER_CACHE_TIME is not None
+        else view
+    )

--- a/eoxserver/services/config.py
+++ b/eoxserver/services/config.py
@@ -1,0 +1,28 @@
+# ------------------------------------------------------------------------------
+#
+# Project: EOxServer <http://eoxserver.org>
+# Authors: Bernhard Mallinger <bernhard.mallinger@eox.at>
+#
+# ------------------------------------------------------------------------------
+# Copyright (C) 2022 EOX IT Services GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies of this Software or works derived from this Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# ------------------------------------------------------------------------------
+
+DEFAULT_EOXS_RENDERER_CACHE_TIME = 60 * 60 * 24 * 7

--- a/eoxserver/services/opensearch/urls.py
+++ b/eoxserver/services/opensearch/urls.py
@@ -31,16 +31,20 @@ try:
 except ImportError:
     from django.urls import include, re_path
 
+from eoxserver.services.config import apply_cache_header
 from eoxserver.services.opensearch.views import description, search
+
+
+search_cached = apply_cache_header(search)
 
 app_name = 'opensearch'
 urlpatterns = [
     re_path(r'^$', description, name='description'),
-    re_path(r'^(?P<format_name>[^/]+)/$', search, name='search'),
+    re_path(r'^(?P<format_name>[^/]+)/$', search_cached, name='search'),
     re_path(r'^collections/(?P<collection_id>[^/]+)/', include(([
         re_path(r'^$', description, name='description'),
         re_path(
-            r'^(?P<format_name>[^/]+)/$', search,
+            r'^(?P<format_name>[^/]+)/$', search_cached,
             name='search'
         )
     ], 'collection')))

--- a/eoxserver/services/opensearch/views.py
+++ b/eoxserver/services/opensearch/views.py
@@ -26,9 +26,12 @@
 #-------------------------------------------------------------------------------
 
 
+from django.conf import settings
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.cache import cache_control
+
+from eoxserver.services import config
 
 from eoxserver.services.opensearch.v11.description import (
     OpenSearch11DescriptionHandler
@@ -50,7 +53,7 @@ def description(request, collection_id=None):
     )
 
 
-@cache_control(max_age=60 * 60 * 24 * 7)
+@cache_control(max_age=getattr(settings, "EOXS_RENDERER_CACHE_TIME", config.DEFAULT_EOXS_RENDERER_CACHE_TIME))
 @csrf_exempt
 def search(request, collection_id=None, format_name=None):
     content, content_type = OpenSearch11SearchHandler().handle(

--- a/eoxserver/services/opensearch/views.py
+++ b/eoxserver/services/opensearch/views.py
@@ -29,9 +29,6 @@
 from django.conf import settings
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.cache import cache_control
-
-from eoxserver.services import config
 
 from eoxserver.services.opensearch.v11.description import (
     OpenSearch11DescriptionHandler
@@ -53,7 +50,6 @@ def description(request, collection_id=None):
     )
 
 
-@cache_control(max_age=getattr(settings, "EOXS_RENDERER_CACHE_TIME", config.DEFAULT_EOXS_RENDERER_CACHE_TIME))
 @csrf_exempt
 def search(request, collection_id=None, format_name=None):
     content, content_type = OpenSearch11SearchHandler().handle(

--- a/eoxserver/services/opensearch/views.py
+++ b/eoxserver/services/opensearch/views.py
@@ -28,6 +28,7 @@
 
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.cache import cache_control
 
 from eoxserver.services.opensearch.v11.description import (
     OpenSearch11DescriptionHandler
@@ -49,6 +50,7 @@ def description(request, collection_id=None):
     )
 
 
+@cache_control(max_age=60 * 60 * 24 * 7)
 @csrf_exempt
 def search(request, collection_id=None, format_name=None):
     content, content_type = OpenSearch11SearchHandler().handle(

--- a/eoxserver/services/urls.py
+++ b/eoxserver/services/urls.py
@@ -35,9 +35,10 @@ except ImportError:
     from django.urls import reverse
 
 from eoxserver.services import views
+from eoxserver.services.config import apply_cache_header
 
 urlpatterns = [
-    re_path(r'^$', views.ows, name='ows')
+    re_path(r'^$', apply_cache_header(views.ows), name='ows',)
 ]
 
 

--- a/eoxserver/services/views.py
+++ b/eoxserver/services/views.py
@@ -41,11 +41,9 @@ except:
     class StreamingHttpResponse(object):
         pass
 from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.cache import cache_control
 from django.utils.six import string_types
 
 from eoxserver.core import env
-from eoxserver.services import config
 from eoxserver.services.ows.component import ServiceComponent
 from eoxserver.services.exceptions import HTTPMethodNotAllowedError
 from eoxserver.services.ows.dispatch import (
@@ -56,7 +54,6 @@ from eoxserver.services.ows.dispatch import (
 logger = logging.getLogger(__name__)
 
 
-@cache_control(max_age=getattr(settings, "EOXS_RENDERER_CACHE_TIME", config.DEFAULT_EOXS_RENDERER_CACHE_TIME))
 @csrf_exempt
 def ows(request):
     """ Main entry point for OWS requests against EOxServer. It uses the

--- a/eoxserver/services/views.py
+++ b/eoxserver/services/views.py
@@ -40,6 +40,7 @@ except:
     class StreamingHttpResponse(object):
         pass
 from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.cache import cache_control
 from django.utils.six import string_types
 
 from eoxserver.core import env
@@ -53,6 +54,7 @@ from eoxserver.services.ows.dispatch import (
 logger = logging.getLogger(__name__)
 
 
+@cache_control(max_age=60 * 60 * 24 * 7)
 @csrf_exempt
 def ows(request):
     """ Main entry point for OWS requests against EOxServer. It uses the

--- a/eoxserver/services/views.py
+++ b/eoxserver/services/views.py
@@ -33,6 +33,7 @@ function is :func:`ows` which handles all incoming OWS requests"""
 import logging
 import traceback
 
+from django.conf import settings
 from django.http import HttpResponse
 try:
     from django.http import StreamingHttpResponse
@@ -44,6 +45,7 @@ from django.views.decorators.cache import cache_control
 from django.utils.six import string_types
 
 from eoxserver.core import env
+from eoxserver.services import config
 from eoxserver.services.ows.component import ServiceComponent
 from eoxserver.services.exceptions import HTTPMethodNotAllowedError
 from eoxserver.services.ows.dispatch import (
@@ -54,7 +56,7 @@ from eoxserver.services.ows.dispatch import (
 logger = logging.getLogger(__name__)
 
 
-@cache_control(max_age=60 * 60 * 24 * 7)
+@cache_control(max_age=getattr(settings, "EOXS_RENDERER_CACHE_TIME", config.DEFAULT_EOXS_RENDERER_CACHE_TIME))
 @csrf_exempt
 def ows(request):
     """ Main entry point for OWS requests against EOxServer. It uses the


### PR DESCRIPTION
Currently this includes opensearch search and ows.

Are there other urls that should be included here?

Should we add caching in a more central location than just adding it to every view individually?