### PR TITLE
Use `exec` instead of `eval` in entrypoint

### DIFF
--- a/docker/eoxserver-entrypoint.sh
+++ b/docker/eoxserver-entrypoint.sh
@@ -81,4 +81,4 @@ fi
 cd "${INSTANCE_DIR}"
 
 # run the initial command
-eval $@
+exec $@


### PR DESCRIPTION
This way, gunicorn replaces the initial bash process and receives signals, such that it terminates quickly on SIGTERM.