### PR TITLE
Fix overflow in interpolate function

### DIFF
--- a/eoxserver/render/browse/functions.py
+++ b/eoxserver/render/browse/functions.py
@@ -260,6 +260,8 @@ def interpolate(ds, x1, x2, y1, y2):
     """Perform linear interpolation for x between (x1,y1) and (x2,y2) """
     band = ds.GetRasterBand(1)
     x = band.ReadAsArray()
+    # NOTE: this formula uses large numbers which lead to overflows on uint16
+    x = x.astype("int64")
     x = ((y2 - y1) * x + x2 * y1 - x1 * y2) / (x2 - x1)
     return gdal_array.OpenNumPyArray(x, True)
 


### PR DESCRIPTION
The input data was read as uint16, which wraps around at 65k, which is actually reached by this formula depending on the interpolate target range.

E.g. one pixel color happened to be 618, leading to a calculation like this:

`( ( 255 - 100 ) * 618 + 814 * 100 - 560 * 255 ) / ( 815 - 560 )`

So evaluating this would start with `(255 - 100) * 618` which is 95790, but with uint16, you get 30254.

The subtraction later made basically all values negative.