### PR TITLE
Interpolate and LUT rendering updates

### DIFF
--- a/eoxserver/render/browse/functions.py
+++ b/eoxserver/render/browse/functions.py
@@ -212,10 +212,6 @@ def percentile(ds, perc, default=0):
     if histogram:
         min_, max_, _, buckets = histogram
         bucket_diff = (max_ - min_) / len(buckets)
-        nodata = band.GetNoDataValue()
-        if nodata is not None:
-            # Set bucket of nodata value to 0
-            buckets[round((nodata - min_) / bucket_diff)] = 0
         cumsum = np.cumsum(buckets)
         bucket_index = np.searchsorted(cumsum, cumsum[-1] * (perc / 100))
         return min_ + (bucket_index * bucket_diff)

--- a/eoxserver/render/browse/functions.py
+++ b/eoxserver/render/browse/functions.py
@@ -28,6 +28,7 @@
 import logging
 from uuid import uuid4
 from functools import wraps
+from typing import List, SupportsFloat as Numeric
 
 import numpy as np
 
@@ -253,26 +254,44 @@ def statistics_stddev(ds, default=0):
     return default
 
 
-def interpolate(ds, x1, x2, y1, y2, clamp=False):
-    """Perform linear interpolation for x between (x1,y1) and (x2,y2) """
+def interpolate(
+        ds:gdal.Dataset, x1:Numeric, x2:Numeric, y1:Numeric, y2:Numeric, clip:bool=False, nodata_range:List[Numeric]=None
+    ):
+    """Perform linear interpolation for x between (x1,y1) and (x2,y2) with
+    optional clamp and additional masking out multiple no data value ranges
+
+    Args:
+        ds (gdal.Dataset): input gdal dataset
+        x1 (Numeric): linear interpolate from min
+        x2 (Numeric): linear interpolate from max
+        y1 (Numeric): linear interpolate to min
+        y2 (Numeric): linear interpolate to max
+        clip (bool, optional): if set to True, performs clip (values below y1 set to y1, values above y2 set to y2). Defaults to False.
+        additional_no_data (List, optional): additionally masks out (sets to band no_data_value) a range of values. Defaults to []. Example [1,5]
+
+    Returns:
+        gdal.Dataset: Interpolated dataset
+    """
     band = ds.GetRasterBand(1)
-    no_data_value = band.GetNoDataValue()
+    nodata_value = band.GetNoDataValue()
     orig_image = band.ReadAsArray()
     # NOTE: the interpolate formula uses large numbers which lead to overflows on uint16
     if orig_image.dtype != convert_dtype(orig_image.dtype):
         orig_image = orig_image.astype(convert_dtype(orig_image.dtype))
     interpolated_image = ((y2 - y1) * orig_image + x2 * y1 - x1 * y2) / (x2 - x1)
-    if clamp:
+    if clip:
         # clamp values below min to min and above max to max
-        interpolated_image[interpolated_image < y1] = y1
-        interpolated_image[interpolated_image > y2] = y2
+        np.clip(interpolated_image, y1, y2, out=interpolated_image)
 
-    if no_data_value is not None:
+    if nodata_value is not None:
         # restore nodata pixels on interpolated array from original array
-        interpolated_image[orig_image == no_data_value] = no_data_value
+        interpolated_image[orig_image == nodata_value] = nodata_value
+        if nodata_range:
+            # apply mask of additional nodata ranges from original array on interpolated array
+            interpolated_image[(orig_image >= nodata_range[0]) & (orig_image <= nodata_range[1])] = nodata_value
 
     ds = gdal_array.OpenNumPyArray(interpolated_image, True)
-    ds.GetRasterBand(1).SetNoDataValue(no_data_value)
+    ds.GetRasterBand(1).SetNoDataValue(nodata_value)
     return ds
 
 

--- a/eoxserver/render/browse/generate.py
+++ b/eoxserver/render/browse/generate.py
@@ -116,6 +116,7 @@ ALLOWED_NODE_TYPES = (
     _ast.Add,
     _ast.Sub,
     _ast.Num if hasattr(_ast, 'Num') else _ast.Constant,
+    _ast.List,
 
     _ast.BitAnd,
     _ast.BitOr,
@@ -490,6 +491,12 @@ def _evaluate_expression(expr, fields_and_datasets, variables, cache):
     elif hasattr(_ast, 'Constant') and isinstance(expr, _ast.Constant):
         result = expr.value
 
+    elif hasattr(_ast, 'List') and isinstance(expr, _ast.List):
+        result = [
+            _evaluate_expression(
+                item, fields_and_datasets, variables, cache,
+            ) for item in expr.elts
+        ]
     else:
         raise BandExpressionError('Invalid expression node %s' % expr)
 

--- a/eoxserver/render/browse/util.py
+++ b/eoxserver/render/browse/util.py
@@ -1,7 +1,11 @@
 from uuid import uuid4
+import numpy as np
+import logging
 
 from eoxserver.contrib import gdal, osr
 from eoxserver.resources.coverages import crss
+
+logger = logging.getLogger(__name__)
 
 
 def create_mem_ds(width, height, data_type):
@@ -78,3 +82,27 @@ def warp_fields(coverages, field_name, bbox, crs, width, height):
             gdal.Unlink(vrt_filename)
 
     return out_ds
+
+
+def convert_dtype(dtype:np.dtype):
+    """Maps numpy dtype to a larger itemsize
+    to avoid value overflow during mathematical operations
+
+    Args:
+        dtype (np.dtype): input dtype
+
+    Returns:
+        dtype (np.dtype): either one size larger dtype or original dtype
+    """
+    mapping = {
+        np.dtype(np.int8): np.dtype(np.int16),
+        np.dtype(np.int16): np.dtype(np.int32),
+        np.dtype(np.int32): np.dtype(np.int64),
+        np.dtype(np.uint8): np.dtype(np.int16),
+        np.dtype(np.uint16): np.dtype(np.int32),
+        np.dtype(np.uint32): np.dtype(np.int64),
+        np.dtype(np.float16): np.dtype(np.float32),
+        np.dtype(np.float32): np.dtype(np.float64),
+    }
+    output_dtype = mapping.get(dtype, dtype)
+    return output_dtype


### PR DESCRIPTION
- update interpolate to allow clamp and masking arbitrary nodata value ranges
- fix data type UInt16 and others overflow during interpolate
- update LUT to mask out just the browse_type.nodata value and nothing else
- LUT rendering currently usable only for positive whole ranges