### PR TITLE
CLI update models via replace parameter

### DIFF
--- a/eoxserver/resources/coverages/management/commands/browsetype.py
+++ b/eoxserver/resources/coverages/management/commands/browsetype.py
@@ -109,6 +109,13 @@ class Command(CommandOutputMixIn, SubParserMixIn, BaseCommand):
             action="store_true",
             default=False,
         )
+        create_parser.add_argument(
+            '--replace', action='store_true',
+            default=False,
+            help=(
+                '''Change browse type if browse type already exists.'''
+            )
+        )
 
 
         list_parser.add_argument(
@@ -141,6 +148,7 @@ class Command(CommandOutputMixIn, SubParserMixIn, BaseCommand):
                       red_or_grey_nodata=None, green_nodata=None,
                       blue_nodata=None, alpha_nodata=None,
                       show_out_of_bounds_data=False,
+                      replace=False,
                       *args, **kwargs):
         """ Handle the creation of a new browse type.
         """
@@ -158,28 +166,52 @@ class Command(CommandOutputMixIn, SubParserMixIn, BaseCommand):
         green_min, green_max = green_range
         blue_min, blue_max = blue_range
         alpha_min, alpha_max = alpha_range
-
-        models.BrowseType.objects.create(
-            product_type=product_type,
-            name=browse_type_name,
-            red_or_grey_expression=red_or_grey_expression,
-            green_expression=green_expression,
-            blue_expression=blue_expression,
-            alpha_expression=alpha_expression,
-            red_or_grey_range_min=red_min,
-            red_or_grey_range_max=red_max,
-            green_range_min=green_min,
-            green_range_max=green_max,
-            blue_range_min=blue_min,
-            blue_range_max=blue_max,
-            alpha_range_min=alpha_min,
-            alpha_range_max=alpha_max,
-            red_or_grey_nodata_value=red_or_grey_nodata,
-            green_nodata_value=green_nodata,
-            blue_nodata_value=blue_nodata,
-            alpha_nodata_value=alpha_nodata,
-            show_out_of_bounds_data=show_out_of_bounds_data,
-        )
+        if replace:
+            models.BrowseType.objects.update_or_create(
+                product_type=product_type,
+                name=browse_type_name,
+                defaults={
+                    'red_or_grey_expression':red_or_grey_expression,
+                    'green_expression':green_expression,
+                    'blue_expression':blue_expression,
+                    'alpha_expression':alpha_expression,
+                    'red_or_grey_range_min':red_min,
+                    'red_or_grey_range_max':red_max,
+                    'green_range_min':green_min,
+                    'green_range_max':green_max,
+                    'blue_range_min':blue_min,
+                    'blue_range_max':blue_max,
+                    'alpha_range_min':alpha_min,
+                    'alpha_range_max':alpha_max,
+                    'red_or_grey_nodata_value':red_or_grey_nodata,
+                    'green_nodata_value':green_nodata,
+                    'blue_nodata_value':blue_nodata,
+                    'alpha_nodata_value':alpha_nodata,
+                    'show_out_of_bounds_data':show_out_of_bounds_data,
+                },
+            )
+        else:
+            models.BrowseType.objects.create(
+                product_type=product_type,
+                name=browse_type_name,
+                red_or_grey_expression=red_or_grey_expression,
+                green_expression=green_expression,
+                blue_expression=blue_expression,
+                alpha_expression=alpha_expression,
+                red_or_grey_range_min=red_min,
+                red_or_grey_range_max=red_max,
+                green_range_min=green_min,
+                green_range_max=green_max,
+                blue_range_min=blue_min,
+                blue_range_max=blue_max,
+                alpha_range_min=alpha_min,
+                alpha_range_max=alpha_max,
+                red_or_grey_nodata_value=red_or_grey_nodata,
+                green_nodata_value=green_nodata,
+                blue_nodata_value=blue_nodata,
+                alpha_nodata_value=alpha_nodata,
+                show_out_of_bounds_data=show_out_of_bounds_data,
+            )
 
         if not browse_type_name:
             print(

--- a/eoxserver/resources/coverages/management/commands/collection.py
+++ b/eoxserver/resources/coverages/management/commands/collection.py
@@ -73,6 +73,14 @@ class Command(CommandOutputMixIn, SubParserMixIn, BaseCommand):
                 '"platform".'
             )
         )
+        create_parser.add_argument(
+            '--replace', action='store_true',
+            default=False,
+            help=(
+                '''Change collection type references according to parameters
+                if collection type already exists.'''
+            )
+        )
         delete_parser.add_argument(
             '--all', '-a', action="store_true",
             default=False, dest='all_collections',
@@ -155,7 +163,7 @@ class Command(CommandOutputMixIn, SubParserMixIn, BaseCommand):
         elif subcommand == "summary":
             self.handle_summary(identifier[0], *args, **kwargs)
 
-    def handle_create(self, identifier, type_name, grid_name, **kwargs):
+    def handle_create(self, identifier, type_name, grid_name, replace, **kwargs):
         """ Handle the creation of a new collection.
         """
         if grid_name:
@@ -176,11 +184,18 @@ class Command(CommandOutputMixIn, SubParserMixIn, BaseCommand):
                 raise CommandError(
                     "Collection type %r does not exist." % type_name
                 )
-
-        models.Collection.objects.create(
-            identifier=identifier,
-            collection_type=collection_type, grid=grid
-        )
+        if replace:
+            models.Collection.objects.update_or_create(
+                identifier=identifier,
+                defaults={
+                    'collection_type':collection_type,
+                    'grid':grid,
+                }
+            )
+        else:
+            models.Collection.objects.create(
+                identifier=identifier, collection_type=collection_type, grid=grid
+            )
 
         print('Successfully created collection %r' % identifier)
 

--- a/eoxserver/resources/coverages/management/commands/collectiontype.py
+++ b/eoxserver/resources/coverages/management/commands/collectiontype.py
@@ -107,7 +107,7 @@ class Command(CommandOutputMixIn, SubParserMixIn, BaseCommand):
 
         for allowed_coverage_type_name in allowed_coverage_type_names:
             if replace:
-                if not collection_type.allowed_coverage_types.exists(name=allowed_coverage_type_name):
+                if not collection_type.allowed_coverage_types.filter(name=allowed_coverage_type_name).exists():
                     self.add_allowed_coverage_type_name(collection_type, allowed_coverage_type_name)
             else:
                 self.add_allowed_coverage_type_name(collection_type, allowed_coverage_type_name)
@@ -120,7 +120,7 @@ class Command(CommandOutputMixIn, SubParserMixIn, BaseCommand):
 
         for allowed_product_type_name in allowed_product_type_names:
             if replace:
-                if not collection_type.allowed_product_types.exists(name=allowed_product_type_name):
+                if not collection_type.allowed_product_types.filter(name=allowed_product_type_name).exists():
                     self.add_allowed_product_type_name(collection_type, allowed_product_type_name)
             else:
                 self.add_allowed_product_type_name(collection_type, allowed_product_type_name)

--- a/eoxserver/resources/coverages/management/commands/coveragetype.py
+++ b/eoxserver/resources/coverages/management/commands/coveragetype.py
@@ -78,6 +78,15 @@ class Command(CommandOutputMixIn, SubParserMixIn, BaseCommand):
             help='Read the definition from stdin instead from a file.'
         )
 
+        for parser in [create_parser, import_parser]:
+            parser.add_argument(
+                '--replace', action='store_true',
+                default=False,
+                help=(
+                    'Replace field types if coverage type already exists.'
+                )
+            )
+
         delete_parser.add_argument(
             '--force', '-f', action='store_true', default=False,
             help='Also remove all collections associated with that type.'
@@ -117,28 +126,28 @@ class Command(CommandOutputMixIn, SubParserMixIn, BaseCommand):
                 wavelength=field_type_definition[4]
             )
             for field_type_definition in field_types
-        ])
+        ], kwargs.get('replace'))
 
         print('Successfully created coverage type %r' % name)
 
     def handle_import(self, locations, *args, **kwargs):
-        def _import(definitions):
+        def _import(definitions, replace):
             if isinstance(definitions, dict):
                 definitions = [definitions]
 
             for definition in definitions:
-                self._import_definition(definition)
+                self._import_definition(definition, replace)
 
-        if kwargs['stdin']:
+        if kwargs.get('stdin'):
             try:
-                _import(json.load(sys.stdin))
+                _import(json.load(sys.stdin), kwargs.get('replace'))
             except ValueError:
                 raise CommandError('Could not parse JSON from stdin')
         else:
             for location in locations:
                 with open(location) as f:
                     try:
-                        _import(json.load(f))
+                        _import(json.load(f), kwargs.get('replace'))
                     except ValueError:
                         raise CommandError(
                             'Could not parse JSON from %r' % location
@@ -183,31 +192,34 @@ class Command(CommandOutputMixIn, SubParserMixIn, BaseCommand):
                 for coverage_type in coverage_type.field_types.all():
                     print("\t%s" % coverage_type.identifier)
 
-    def _import_definition(self, definition):
+    def _import_definition(self, definition, replace):
         name = str(definition['name'])
         coverage_type = self._create_coverage_type(name)
         field_type_definitions = (
             definition.get('field_type') or definition.get('bands')
         )
         self._create_field_types(
-            coverage_type, definition, field_type_definitions
+            coverage_type, definition, field_type_definitions, replace
         )
         self.print_msg('Successfully imported coverage type %r' % name)
 
     def _create_coverage_type(self, name):
         try:
-            return models.CoverageType.objects.create(name=name)
+            return models.CoverageType.objects.get_or_create(name=name)[0]
         except IntegrityError:
             raise CommandError("Coverage type %r already exists." % name)
 
     def _create_field_types(self, coverage_type, coverage_type_definition,
-                            field_type_definitions):
+                            field_type_definitions, replace):
         for i, field_type_definition in enumerate(field_type_definitions):
             uom = (
                 field_type_definition.get('unit_of_measure') or
                 field_type_definition.get('uom')
             )
-
+            if replace:
+                # delete all FieldTypes attached to CoverageType if any exist
+                field_types = models.FieldType.objects.filter(coverage_type=coverage_type)
+                field_types.delete()
             field_type = models.FieldType(
                 coverage_type=coverage_type,
                 index=i,


### PR DESCRIPTION
Adds option to update existing models from CLI for following models: BrowseType, CoverageType, Storage, StorageAuth, ProductType, CollectionType, Collection.

If replace parameter not added, the methods used (model.create) are left the same to ensure backwards compatibility - that Exception is thrown if model of that unique key already exists.