### PR TITLE
Handling of NetCDF Data

### DIFF
--- a/eoxserver/contrib/gdal.py
+++ b/eoxserver/contrib/gdal.py
@@ -184,4 +184,10 @@ def config_env(env, fail_on_override=False, reset_old=True):
 
 def open_with_env(path, env, shared=True):
     with config_env(env, False):
+        # if attempting to load NETCDF file with additional indexing, need to extract only base path
+        # this loads the variable dataset and allows information to be extracted from first band
+        if "NETCDF" in path:
+            if ("https://" in path and path.count(":") == 4) or (not "https://" in path and path.count(":") == 3):
+                splitpath = path.rsplit(":",1)
+                path = splitpath[0]
         return OpenShared(path) if shared else Open(path)

--- a/eoxserver/render/mapserver/factories.py
+++ b/eoxserver/render/mapserver/factories.py
@@ -669,6 +669,19 @@ def _create_raster_layer_objs(map_obj, extent, sr, data, filename_generator, env
     layer_obj.type = ms.MS_LAYER_RASTER
     layer_obj.status = ms.MS_ON
 
+    # if attempting to load NETCDF file, need to use a temporary file to extract only
+    # the required band data
+    if "NETCDF" in data:
+        # determine if attempting to load a specific band index
+        if ("https://" in data and data.count(":") == 4) or (not "https://" in data and data.count(":") == 3):
+            splitpath = data.rsplit(":",1)
+            data = splitpath[0]
+            index = int(splitpath[1]) + 1
+        temp_path = "/vsimem/%s" % uuid4().hex
+        # extract only desired index to new temporary file
+        gdal.Translate(temp_path, data, bandList=[index])
+        data = temp_path
+
     layer_obj.data = data
     # assumption that RGBA already has transparency in alpha band
     if browse_mode != BROWSE_MODE_RGBA:


### PR DESCRIPTION
## Suggested code updates to support NetCDF data with multiple variables
When loading NetCDF files for rendering via mapserver, due to a limitation in GDAL, the following string is not supported:
`NETCDF:<path-to-data>:<variable-name>:<index>`. This leads to issues when opening the data to access metadata as well as when rendering the data via WMS.
Instead, we are able to extract the desired index from the NetCDF by using `gdal.translate` and save this as a temporary file which can then be used when rendering the data onto the map. This avoids relying on the `gdal.Open` call which does not offer the same functionality for NetCDF as it does for ZARR data formats, i.e. index is not supported.
The same issue has been addressed when opening the NetCDF data to determine its size, here we don't need a temporary file, as simply using the call `NETCDF:<path-to-data>:<variable-name>` is sufficient to extract the correct 2D size of the data.
This PR helps to resolve the issue captured under issue #569.