### PR TITLE
feat(collection): add import subcommand for collection command

### DIFF
--- a/eoxserver/resources/coverages/management/commands/collection.py
+++ b/eoxserver/resources/coverages/management/commands/collection.py
@@ -182,6 +182,13 @@ class Command(CommandOutputMixIn, SubParserMixIn, BaseCommand):
             dest='coverage_import',
             help=("Don't import coverages.")
         )
+        import_parser.add_argument(
+            '--use-extent', action='store_true', default=False,
+            help=(
+                'Whether to simply collect the bounding box of the '
+                'footprint as the collections footprint'
+            )
+        )
 
     @transaction.atomic
     def handle(self, subcommand, identifier, *args, **kwargs):
@@ -348,8 +355,8 @@ class Command(CommandOutputMixIn, SubParserMixIn, BaseCommand):
         print('Successfully collected metadata for collection %r' % identifier)
 
     def handle_import(self, identifier, from_collections, from_producttypes,
-                      from_coveragetypes, product_import,
-                      coverage_import, **kwargs):
+                      from_coveragetypes, product_import, coverage_import,
+                      use_extent, **kwargs):
         collection = self.get_collection(identifier)
 
         collections = [
@@ -372,7 +379,7 @@ class Command(CommandOutputMixIn, SubParserMixIn, BaseCommand):
 
             num_products = len(qs)
             for product in qs:
-                models.collection_insert_eo_object(collection, product)
+                models.collection_insert_eo_object(collection, product, use_extent)
             print("Imported %d products into collection %r." % (num_products, collection))
 
         if coverage_import:
@@ -390,7 +397,7 @@ class Command(CommandOutputMixIn, SubParserMixIn, BaseCommand):
 
             num_coverages = len(qs)
             for coverage in qs:
-                models.collection_insert_eo_object(collection, coverage)
+                models.collection_insert_eo_object(collection, coverage, use_extent)
             print(
                 "Imported %d coverages into collection %r." % (
                     num_coverages, collection

--- a/eoxserver/resources/coverages/management/commands/collection.py
+++ b/eoxserver/resources/coverages/management/commands/collection.py
@@ -373,7 +373,7 @@ class Command(CommandOutputMixIn, SubParserMixIn, BaseCommand):
             num_products = len(qs)
             for product in qs:
                 models.collection_insert_eo_object(collection, product)
-            print("Imported %d products." % num_products)
+            print("Imported %d products into collection %r." % (num_products, collection))
 
         if coverage_import:
             # get distinct coverages that are in the collections in
@@ -391,7 +391,11 @@ class Command(CommandOutputMixIn, SubParserMixIn, BaseCommand):
             num_coverages = len(qs)
             for coverage in qs:
                 models.collection_insert_eo_object(collection, coverage)
-            print("Imported %d coverages." % num_coverages)
+            print(
+                "Imported %d coverages into collection %r." % (
+                    num_coverages, collection
+                )
+            )
 
     def get_collection(self, identifier):
         """ Helper method to get a collection by identifier or raise a

--- a/eoxserver/resources/coverages/tests.py
+++ b/eoxserver/resources/coverages/tests.py
@@ -648,6 +648,7 @@ class CollectionImportCommandTestCase(CommandTestCaseMixIn, TestCase):
             from_coveragetypes=[],
             coverage_import=True,
             product_import=False,
+            use_extent=False,
         )
 
         self.assertIn(self.coverage, self.collection.coverages.all())
@@ -669,6 +670,7 @@ class CollectionImportCommandTestCase(CommandTestCaseMixIn, TestCase):
             from_coveragetypes=[],
             coverage_import=False,
             product_import=True,
+            use_extent=False,
         )
 
         self.assertIn(self.product, self.collection.products.all())
@@ -683,6 +685,7 @@ class CollectionImportCommandTestCase(CommandTestCaseMixIn, TestCase):
             from_coveragetypes=[self.coverage_type.name],
             coverage_import=True,
             product_import=False,
+            use_extent=False,
         )
 
         self.assertIn(self.coverage, self.collection.coverages.all())
@@ -697,6 +700,7 @@ class CollectionImportCommandTestCase(CommandTestCaseMixIn, TestCase):
             from_coveragetypes=[],
             coverage_import=False,
             product_import=True,
+            use_extent=False,
         )
 
         self.assertIn(self.product, self.collection.products.all())


### PR DESCRIPTION
The `collection` command now has an `import` subcommand, allowing to import from other collections, product types or coverage types.